### PR TITLE
Use real address in repository.json

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
 	"name" : "B Tasker HomeAssistant Addons",
-        "url" : "http://example/will/update/later",
+        "url" : "https://github.com/bentasker/HomeAssistantAddons",
         "maintainer": "B Tasker"
 }


### PR DESCRIPTION
Use repo url instead of example.

Spent way too long re-searching for your repo to add to another Home Assistant instance because this was not set. So, FTFY... :)